### PR TITLE
Add root test script for image editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
     "build": "lerna run build",
     "build:image-editor": "lerna run --scope tui-image-editor build",
     "build:react": "lerna run --scope @toast-ui/react-image-editor build",
-    "build:vue": "lerna run --scope @toast-ui/vue-image-editor build"
+    "build:vue": "lerna run --scope @toast-ui/vue-image-editor build",
+    "test": "npm run test:unit",
+    "test:unit": "lerna run --stream --scope tui-image-editor test",
+    "test:types": "lerna run --stream --scope tui-image-editor test:types"
   },
   "workspaces": [
     "apps/*"


### PR DESCRIPTION
## Summary
- add a root-level npm test script that forwards to the image editor's Jest suite
- expose a dedicated script for running the type definition checks via Lerna

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d87e7ce2d48328a3a2ba291ac13ef0